### PR TITLE
Fix None localname error

### DIFF
--- a/src/basestation_ctrl/basestation_ctrl.py
+++ b/src/basestation_ctrl/basestation_ctrl.py
@@ -23,7 +23,7 @@ class BasestationCtrl:
         results = {}
         for dev in devices:
             localname = dev.getValueText(BasestationCtrl.LOCALNAME_ADTYPE)
-            if print_all or localname.startswith("LHB-"):
+            if print_all or (localname and localname.startswith("LHB-")):
                 results[localname] = dev.addr
 
         return results


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "/home/libor/basestation-mqtt-daemon/main.py", line 11, in <module>
    main()
  File "/home/libor/basestation-mqtt-daemon/main.py", line 5, in main
    results = basestation.scan(10.)
              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/libor/basestation-mqtt-daemon/venv/lib/python3.11/site-packages/basestation_ctrl/basestation_ctrl.py", line 26, in scan
    if print_all or localname.startswith("LHB-"):
                    ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'startswith'
```